### PR TITLE
chore(deps): upgrade prettier to v3, update eslint plugins

### DIFF
--- a/config/config.json.example
+++ b/config/config.json.example
@@ -10,7 +10,7 @@
     // only use one:
     "whitelist": [],
     // OR
-    "blacklist": [],
+    "blacklist": []
   },
   "database": {
     "name": "",
@@ -22,14 +22,14 @@
   },
   "commands": {
     "didAThing": [
-      { 
-        "name": "(name we call it)", 
+      {
+        "name": "(name we call it)",
         "role": "(name of role in Discord)",
         "color": "#RGBCOL"
       }
-    ],
+    ]
   },
-  workers: {
+  "workers": {
     "reactionRoles": [
       {
         "emojiName": "🤷",
@@ -38,5 +38,5 @@
         "color": "#RGBCOL"
       }
     ]
-  },
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,12 +26,12 @@
         "cross-env": "^7.0.3",
         "eslint": "^8.25.0",
         "eslint-config-airbnb-base": "^15.0.0",
-        "eslint-config-prettier": "^8.10.0",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import": "^2.32.0",
-        "eslint-plugin-prettier": "^3.4.1",
+        "eslint-plugin-prettier": "^5.5.6",
         "nodemon": "^3.1.14",
         "pkg": "^5.7.0",
-        "prettier": "^2.8.8"
+        "prettier": "^3.9.5"
       }
     },
     "node_modules/@babel/generator": {
@@ -482,6 +482,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -1870,12 +1883,16 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
-      "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
@@ -2024,21 +2041,31 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
-      "integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.6.tgz",
+      "integrity": "sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
+        "prettier-linter-helpers": "^1.0.1",
+        "synckit": "^0.11.13"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
       },
       "peerDependencies": {
-        "eslint": ">=5.0.0",
-        "prettier": ">=1.13.0"
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
       },
       "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
         "eslint-config-prettier": {
           "optional": true
         }
@@ -2244,7 +2271,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -4319,25 +4347,27 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
+      "integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-diff": "^1.1.2"
       },
@@ -5203,6 +5233,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.3.6"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
       }
     },
     "node_modules/tar": {
@@ -6306,6 +6352,12 @@
         "fastq": "^1.6.0"
       }
     },
+    "@pkgr/core": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
+      "dev": true
+    },
     "@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -7351,9 +7403,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
-      "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "requires": {}
     },
@@ -7456,12 +7508,13 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
-      "integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.6.tgz",
+      "integrity": "sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==",
       "dev": true,
       "requires": {
-        "prettier-linter-helpers": "^1.0.0"
+        "prettier-linter-helpers": "^1.0.1",
+        "synckit": "^0.11.13"
       }
     },
     "eslint-scope": {
@@ -8949,15 +9002,15 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true
     },
     "prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
+      "integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
       "dev": true,
       "requires": {
         "fast-diff": "^1.1.2"
@@ -9511,6 +9564,15 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
+    },
+    "synckit": {
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
+      "dev": true,
+      "requires": {
+        "@pkgr/core": "^0.3.6"
+      }
     },
     "tar": {
       "version": "7.5.19",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "cross-env": "^7.0.3",
     "eslint": "^8.25.0",
     "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-config-prettier": "^8.10.0",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-prettier": "^3.4.1",
+    "eslint-plugin-prettier": "^5.5.6",
     "nodemon": "^3.1.14",
     "pkg": "^5.7.0",
-    "prettier": "^2.8.8"
+    "prettier": "^3.9.5"
   },
   "pkg": {
     "outputPath": "dist",

--- a/src/commands/did-a-thing.js
+++ b/src/commands/did-a-thing.js
@@ -1,5 +1,5 @@
 import { ApplicationCommandOptionType, EmbedBuilder } from "discord.js";
-import config from "../../config/config.json" assert { type: "json" };
+import config from "../../config/config.json" with { type: "json" };
 
 const { String } = ApplicationCommandOptionType;
 
@@ -30,10 +30,10 @@ const init = async (interaction, client, sequelize) => {
   const caption = interaction.options.getString("caption");
   const thingObject = things.find(({ name }) => name === thing);
   const role = member.guild.roles.cache.find(
-    ({ name }) => name === thingObject.role
+    ({ name }) => name === thingObject.role,
   );
   const expirationDateTime = new Date(
-    new Date().getTime() + 24 * 60 * 60 * 1000
+    new Date().getTime() + 24 * 60 * 60 * 1000,
   );
 
   const TempRole = (

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import fs from "fs";
 import path from "path";
 import { Sequelize } from "sequelize";
 import { formatInTimeZone } from "date-fns-tz";
-import config from "../config/config.json" assert { type: "json" };
+import config from "../config/config.json" with { type: "json" };
 import canPostInChannel from "./utils/canPostInChannel.js";
 import sendDebugMessage from "./utils/sendDebugMessage.js";
 import "colors";
@@ -42,7 +42,7 @@ const sequelize = new Sequelize(
     dialect: process.env.DB_DIALECT,
     storage: process.env.DB_STORAGE,
     logging: false,
-  }
+  },
 );
 
 // Import the TempRole model
@@ -57,17 +57,17 @@ client.once("ready", async () => {
   const formattedDate = formatInTimeZone(
     now,
     "America/Chicago",
-    "MMMM do yyyy, h:mm:ss a zzz"
+    "MMMM do yyyy, h:mm:ss a zzz",
   );
   sendDebugMessage(
     client,
     `${config.bot.namePrefix}Squiggle came online at ${formattedDate}`,
-    { emoji: "😃", color: "red", bold: true }
+    { emoji: "😃", color: "red", bold: true },
   );
 
   // Load and register commands
   const commandsFiles = fs.readdirSync(
-    path.join(global.appRoot, "./src/commands")
+    path.join(global.appRoot, "./src/commands"),
   );
   const commandPromises = commandsFiles.map(async (file) => {
     const commandModule = await import(`./commands/${file}`);
@@ -114,7 +114,7 @@ client.once("ready", async () => {
       emoji: "⌨️",
     });
     const commandMessages = commands.map(
-      (command) => `\`/${command.name}\`: ${command.description}`
+      (command) => `\`/${command.name}\`: ${command.description}`,
     );
     sendDebugMessage(client, commandMessages, { suboption: true });
   } catch (error) {
@@ -122,7 +122,7 @@ client.once("ready", async () => {
     await sendDebugMessage(
       client,
       `Error registering commands: ${JSON.stringify(error, null, 2)}`,
-      { emoji: "⚠️", color: "red", bold: true }
+      { emoji: "⚠️", color: "red", bold: true },
     );
   }
 });
@@ -146,8 +146,8 @@ client.on("interactionCreate", async (interaction) => {
         `Error executing command ${commandName}: ${JSON.stringify(
           error,
           null,
-          2
-        )}`
+          2,
+        )}`,
       );
       await interaction.reply({
         content: "Something went wrong while executing the command.",
@@ -173,7 +173,7 @@ client.on("messageReactionAdd", async (reaction, user) => {
     } catch (error) {
       await sendDebugMessage(
         client,
-        `Error fetching message: ${error.message}`
+        `Error fetching message: ${error.message}`,
       );
       return;
     }
@@ -190,23 +190,23 @@ client.on("messageReactionAdd", async (reaction, user) => {
       try {
         const { guild } = message;
         const role = guild.roles.cache.find(
-          (findableRole) => findableRole.name === reactionRole.roleName
+          (findableRole) => findableRole.name === reactionRole.roleName,
         );
         if (!role) {
           await sendDebugMessage(
             client,
-            `Role ${reactionRole.roleName} not found`
+            `Role ${reactionRole.roleName} not found`,
           );
           return;
         }
 
         const member = guild.members.cache.find(
-          (findableMember) => findableMember.id === message.author.id
+          (findableMember) => findableMember.id === message.author.id,
         );
         if (!member) {
           await sendDebugMessage(
             client,
-            `Member ${message.author.id} not found`
+            `Member ${message.author.id} not found`,
           );
           return;
         }
@@ -235,13 +235,13 @@ client.on("messageReactionAdd", async (reaction, user) => {
           if (reaction.count >= threshold) {
             // Update the expiration time by adding 4 hours
             expirationTime = new Date(
-              existingTempRole.expirationTime.getTime() + 4 * 60 * 60 * 1000
+              existingTempRole.expirationTime.getTime() + 4 * 60 * 60 * 1000,
             );
             await existingTempRole.update({ expirationTime });
 
             // Send a message to the channel
             await message.reply(
-              `${extenderName} extended your role by four hours`
+              `${extenderName} extended your role by four hours`,
             );
           }
         } else {
@@ -249,7 +249,7 @@ client.on("messageReactionAdd", async (reaction, user) => {
           if (reaction.count >= threshold) {
             // Set the expiration time to 16 hours from now
             expirationTime = new Date(
-              new Date().getTime() + 16 * 60 * 60 * 1000
+              new Date().getTime() + 16 * 60 * 60 * 1000,
             );
 
             // Create a new instance of the role in the database
@@ -270,8 +270,8 @@ client.on("messageReactionAdd", async (reaction, user) => {
               .setTitle(
                 `${memberName} was determined to be ${reactionRole.roleName.replace(
                   /People who are /g,
-                  ""
-                )}`
+                  "",
+                )}`,
               )
               .setColor(reactionRole.color)
               .setAuthor({
@@ -286,10 +286,10 @@ client.on("messageReactionAdd", async (reaction, user) => {
       } catch (error) {
         await sendDebugMessage(
           client,
-          `Error handling reaction: ${JSON.stringify(error, null, 2)}`
+          `Error handling reaction: ${JSON.stringify(error, null, 2)}`,
         );
         await message.channel.send(
-          "Something went wrong with storing a tempRole."
+          "Something went wrong with storing a tempRole.",
         );
       }
     }

--- a/src/utils/canPostInChannel.js
+++ b/src/utils/canPostInChannel.js
@@ -1,4 +1,4 @@
-import config from "../../config/config.json" assert { type: "json" };
+import config from "../../config/config.json" with { type: "json" };
 
 /**
  * Determines if the bot can post in a given channel based on whitelist/blacklist configuration.

--- a/src/utils/sendDebugMessage.js
+++ b/src/utils/sendDebugMessage.js
@@ -46,7 +46,7 @@ const sendDebugMessage = async (client, messages, options = {}) => {
 
   // Send formatted message to Discord
   const debugChannel = client.channels.cache.find(
-    (ch) => ch.name === "🤖bot-messages"
+    (ch) => ch.name === "🤖bot-messages",
   );
   if (debugChannel) {
     await debugChannel.send(plainMessage);


### PR DESCRIPTION
## Summary
- Upgrades `prettier` 2→3, `eslint-plugin-prettier` 3→5, `eslint-config-prettier` 8→10
- Migrates import assertions from deprecated `assert` to `with` keyword (TC39 Import Attributes spec change, supported natively in Node 22)

## Test plan
- [ ] `npm run format` runs clean
- [ ] `npm run lint` passes