### PR TITLE
chore(deps): upgrade dotenv to v17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "date-fns-tz": "^3.2.0",
         "discord-api-types": "^0.37.100",
         "discord.js": "^14.16.2",
-        "dotenv": "^10.0.0",
+        "dotenv": "^17.4.2",
         "sequelize": "^6.23.0",
         "sqlite3": "^6.0.1",
         "winston": "^3.19.0"
@@ -1537,11 +1537,15 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dottie": {
@@ -7091,9 +7095,9 @@
       }
     },
     "dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="
     },
     "dottie": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "date-fns-tz": "^3.2.0",
     "discord-api-types": "^0.37.100",
     "discord.js": "^14.16.2",
-    "dotenv": "^10.0.0",
+    "dotenv": "^17.4.2",
     "sequelize": "^6.23.0",
     "sqlite3": "^6.0.1",
     "winston": "^3.19.0"


### PR DESCRIPTION
## Summary
- Upgrades `dotenv` 10→17; public `dotenv.config()` API unchanged across all intermediate majors

## Test plan
- [ ] Bot starts and reads env vars correctly