### PR TITLE
chore(deps): upgrade date-fns to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@discordjs/rest": "^2.4.0",
         "colors": "^1.4.0",
-        "date-fns": "^3.6.0",
+        "date-fns": "^4.4.0",
         "date-fns-tz": "^3.2.0",
         "discord-api-types": "^0.37.100",
         "discord.js": "^14.16.2",
@@ -1364,9 +1364,10 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -6974,9 +6975,9 @@
       }
     },
     "date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w=="
     },
     "date-fns-tz": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@discordjs/rest": "^2.4.0",
     "colors": "^1.4.0",
-    "date-fns": "^3.6.0",
+    "date-fns": "^4.4.0",
     "date-fns-tz": "^3.2.0",
     "discord-api-types": "^0.37.100",
     "discord.js": "^14.16.2",


### PR DESCRIPTION
## Summary
- Upgrades `date-fns` 3→4; only `formatInTimeZone` from `date-fns-tz` is used (no direct `date-fns` imports), and `date-fns-tz` supports both v3 and v4

## Test plan
- [ ] Bot startup timestamp formats correctly