### PR TITLE
chore(deps): upgrade discord-api-types to v0.38

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "colors": "^1.4.0",
         "date-fns": "^4.4.0",
         "date-fns-tz": "^3.2.0",
-        "discord-api-types": "^0.37.100",
+        "discord-api-types": "^0.38.49",
         "discord.js": "^14.16.2",
         "dotenv": "^17.4.2",
         "sequelize": "^6.23.0",
@@ -133,15 +133,6 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
-    "node_modules/@discordjs/builders/node_modules/discord-api-types": {
-      "version": "0.38.49",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.49.tgz",
-      "integrity": "sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
-    },
     "node_modules/@discordjs/collection": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
@@ -167,15 +158,6 @@
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
-    },
-    "node_modules/@discordjs/formatters/node_modules/discord-api-types": {
-      "version": "0.38.49",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.49.tgz",
-      "integrity": "sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
     },
     "node_modules/@discordjs/rest": {
       "version": "2.6.1",
@@ -210,15 +192,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@discordjs/rest/node_modules/discord-api-types": {
-      "version": "0.38.49",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.49.tgz",
-      "integrity": "sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
-    },
     "node_modules/@discordjs/util": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
@@ -233,15 +206,6 @@
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
-    },
-    "node_modules/@discordjs/util/node_modules/discord-api-types": {
-      "version": "0.38.49",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.49.tgz",
-      "integrity": "sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
     },
     "node_modules/@discordjs/ws": {
       "version": "1.2.3",
@@ -265,15 +229,6 @@
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
-    },
-    "node_modules/@discordjs/ws/node_modules/discord-api-types": {
-      "version": "0.38.49",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.49.tgz",
-      "integrity": "sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
     },
     "node_modules/@epic-web/invariant": {
       "version": "1.0.0",
@@ -1484,9 +1439,13 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.100",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.100.tgz",
-      "integrity": "sha512-a8zvUI0GYYwDtScfRd/TtaNBDTXwP5DiDVX7K5OmE+DRT57gBqKnwtOC5Ol8z0mRW8KQfETIgiB8U0YZ9NXiCA=="
+      "version": "0.38.49",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.49.tgz",
+      "integrity": "sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
     },
     "node_modules/discord.js": {
       "version": "14.26.5",
@@ -1522,15 +1481,6 @@
       "engines": {
         "node": ">=16.11.0"
       }
-    },
-    "node_modules/discord.js/node_modules/discord-api-types": {
-      "version": "0.38.49",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.49.tgz",
-      "integrity": "sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -6116,13 +6066,6 @@
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.4",
         "tslib": "^2.6.3"
-      },
-      "dependencies": {
-        "discord-api-types": {
-          "version": "0.38.49",
-          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.49.tgz",
-          "integrity": "sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg=="
-        }
       }
     },
     "@discordjs/collection": {
@@ -6136,13 +6079,6 @@
       "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
       "requires": {
         "discord-api-types": "^0.38.33"
-      },
-      "dependencies": {
-        "discord-api-types": {
-          "version": "0.38.49",
-          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.49.tgz",
-          "integrity": "sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg=="
-        }
       }
     },
     "@discordjs/rest": {
@@ -6165,11 +6101,6 @@
           "version": "3.5.5",
           "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
           "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ=="
-        },
-        "discord-api-types": {
-          "version": "0.38.49",
-          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.49.tgz",
-          "integrity": "sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg=="
         }
       }
     },
@@ -6179,13 +6110,6 @@
       "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
       "requires": {
         "discord-api-types": "^0.38.33"
-      },
-      "dependencies": {
-        "discord-api-types": {
-          "version": "0.38.49",
-          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.49.tgz",
-          "integrity": "sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg=="
-        }
       }
     },
     "@discordjs/ws": {
@@ -6202,13 +6126,6 @@
         "discord-api-types": "^0.38.1",
         "tslib": "^2.6.2",
         "ws": "^8.17.0"
-      },
-      "dependencies": {
-        "discord-api-types": {
-          "version": "0.38.49",
-          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.49.tgz",
-          "integrity": "sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg=="
-        }
       }
     },
     "@epic-web/invariant": {
@@ -7064,9 +6981,9 @@
       }
     },
     "discord-api-types": {
-      "version": "0.37.100",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.100.tgz",
-      "integrity": "sha512-a8zvUI0GYYwDtScfRd/TtaNBDTXwP5DiDVX7K5OmE+DRT57gBqKnwtOC5Ol8z0mRW8KQfETIgiB8U0YZ9NXiCA=="
+      "version": "0.38.49",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.49.tgz",
+      "integrity": "sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg=="
     },
     "discord.js": {
       "version": "14.26.5",
@@ -7092,11 +7009,6 @@
           "version": "1.5.3",
           "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
           "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ=="
-        },
-        "discord-api-types": {
-          "version": "0.38.49",
-          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.49.tgz",
-          "integrity": "sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "colors": "^1.4.0",
     "date-fns": "^4.4.0",
     "date-fns-tz": "^3.2.0",
-    "discord-api-types": "^0.37.100",
+    "discord-api-types": "^0.38.49",
     "discord.js": "^14.16.2",
     "dotenv": "^17.4.2",
     "sequelize": "^6.23.0",


### PR DESCRIPTION
## Summary
- Upgrades `discord-api-types` 0.37→0.38; only `Routes` from the stable `/v10` subpath is used

## Test plan
- [ ] Commands register successfully on bot startup