### PR TITLE
fix: audit bugs, add tests, combined roles, and forwarding

### DIFF
--- a/config/config.json.example
+++ b/config/config.json.example
@@ -35,7 +35,8 @@
         "emojiName": "🤷",
         "threshold": 4, // how many reactions are needed to trigger
         "roleName": "(name of role in Discord)",
-        "color": "#RGBCOL"
+        "color": "#RGBCOL",
+        "forwardChannel": "(optional) channel name to forward the message to on grant"
       }
     ],
     "combinedReactionRoles": [
@@ -43,7 +44,8 @@
         "emojiNames": ["TheBest", "TheWorst"], // all must hit threshold
         "threshold": 4,
         "roleName": "(name of role in Discord)",
-        "color": "#RGBCOL"
+        "color": "#RGBCOL",
+        "forwardChannel": "(optional) channel name to forward the message to on grant"
       }
     ]
   }

--- a/src/commands/did-a-thing.js
+++ b/src/commands/did-a-thing.js
@@ -84,7 +84,6 @@ const init = async (interaction, client, sequelize) => {
         roleName: role.name,
         messageId: reply.id,
         expirationTime: expirationDateTime,
-        source: "command",
       });
     } catch (dbError) {
       await member.roles.remove(role).catch(() => {});

--- a/src/index.js
+++ b/src/index.js
@@ -210,45 +210,10 @@ client.on("messageReactionAdd", async (reaction, user) => {
           return;
         }
 
-        // Bot reactions are filtered at handler entry; subtract bot's own
-        // reaction from count if present so threshold reflects human votes only
+        // Bot reactions filtered at handler entry; subtract bot's own reaction
+        // so threshold reflects human votes only
         const humanCount = reaction.count - (reaction.me ? 1 : 0);
         const { threshold } = reactionRole;
-
-        // If this message is a /did-a-thing post, extend that role instead
-        // of running normal reaction-role logic
-        const commandTempRole = await TempRole.findOne({
-          where: { messageId: message.id, source: "command" },
-        });
-
-        if (commandTempRole) {
-          if (
-            humanCount >= threshold &&
-            humanCount > commandTempRole.maxReactionCount
-          ) {
-            if (!commandTempRole.expirationTime) {
-              throw new Error(
-                `TempRole ${commandTempRole.id} has null expirationTime`,
-              );
-            }
-            const expirationTime = new Date(
-              commandTempRole.expirationTime.getTime() + 4 * 60 * 60 * 1000,
-            );
-            await commandTempRole.update({
-              expirationTime,
-              maxReactionCount: humanCount,
-            });
-            const extenderMember = await guild.members.fetch(user.id);
-            const extenderName = extenderMember.nickname || user.username;
-            const postMember = await guild.members.fetch(message.author.id);
-            const postMemberName =
-              postMember.nickname || postMember.user.username;
-            await message.reply(
-              `${extenderName} encouraged ${postMemberName}! Their role was extended by four hours.`,
-            );
-          }
-          return;
-        }
 
         // Fetch from API instead of cache to guarantee the member is found
         const member = await guild.members.fetch(message.author.id);

--- a/src/index.js
+++ b/src/index.js
@@ -290,6 +290,20 @@ client.on("messageReactionAdd", async (reaction, user) => {
               .setTimestamp();
 
             await message.reply({ embeds: [embed] });
+
+            if (reactionRole.forwardChannel) {
+              const fwdChannel = message.guild.channels.cache.find(
+                (ch) => ch.name === reactionRole.forwardChannel,
+              );
+              if (fwdChannel) {
+                await message.forward(fwdChannel);
+              } else {
+                await sendDebugMessage(
+                  client,
+                  `forwardChannel "${reactionRole.forwardChannel}" not found`,
+                );
+              }
+            }
           }
         }
       } catch (error) {
@@ -398,6 +412,20 @@ client.on("messageReactionAdd", async (reaction, user) => {
             .setTimestamp();
 
           await message.reply({ embeds: [embed] });
+
+          if (combinedRole.forwardChannel) {
+            const fwdChannel = message.guild.channels.cache.find(
+              (ch) => ch.name === combinedRole.forwardChannel,
+            );
+            if (fwdChannel) {
+              await message.forward(fwdChannel);
+            } else {
+              await sendDebugMessage(
+                client,
+                `forwardChannel "${combinedRole.forwardChannel}" not found`,
+              );
+            }
+          }
         }
       } catch (error) {
         await sendDebugMessage(

--- a/src/models/tempRole.js
+++ b/src/models/tempRole.js
@@ -21,10 +21,6 @@ const TempRoleModel = (sequelize) => {
       type: DataTypes.INTEGER,
       defaultValue: 0,
     },
-    source: {
-      type: DataTypes.STRING,
-      defaultValue: "reaction",
-    },
   });
 
   return TempRole;


### PR DESCRIPTION
## Summary

- Fixed multiple bugs: `forEach`+async, missing `await`, double-count gaming via `maxReactionCount` high-water mark, null guards for DMs/missing channels/invalid workers
- Added Vitest test suite (24 tests across utils, models, workers)
- Added combined reaction role support (e.g. TheBest + TheWorst → third role)
- Added 🙌 upvote tracking for `/did-a-thing` posts via existing reactionRoles config
- Added `forwardChannel` support: optionally forward triggering message to a configured channel on role grant
- Migrated ESLint to v10 flat config, upgraded deps (prettier v3, sqlite3 v6, discord-api-types, dotenv, date-fns, cross-env, nodemon)

## Test plan

- [ ] Run `npm test` — 24 tests pass
- [ ] Run `npm run lint` — no errors
- [ ] Deploy and verify reaction roles grant/extend correctly
- [ ] Verify combined TheBest+TheWorst grants THE ABSOLUTE MOST role
- [ ] Verify messages forward to configured channels on initial grant only
- [ ] Verify `/did-a-thing` 🙌 upvotes grant CRUSHED role at threshold 4

🤖 Generated with [Claude Code](https://claude.ai/claude-code)